### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "GuillemRoca"


### PR DESCRIPTION
This pull request introduces Dependabot configuration to automate dependency updates for the project. The configuration specifies the package ecosystem, update schedule, and assignees responsible for managing the updates.

Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R13): Added configuration for Dependabot to manage Gradle dependencies with a weekly update schedule and assigned `GuillemRoca` to handle the updates.